### PR TITLE
fix(default_route): redirect / to default frontend

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -37,6 +37,9 @@ var catfact_output = 'Getting random cat fact';
 
 server = http.createServer(function(request, response){
   var uri = url.parse(request.url).pathname;
+  if (uri === "/") {
+    uri = "/ntg-frontend.html"
+  }
   var filename = path.join(process.cwd(), uri);
   fs.exists(filename, function(exists) {
     if (!exists) {


### PR DESCRIPTION
Don't require adding the full 'ntg-frontend.html' to the URL; if something isn't provided (i.e., user is just on '/') redirect automatically.