### PR TITLE
feat(min_time): enable control of the amount of time given for baselining

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,8 @@ At this point your task should be starting up.
 The running container will make periodic calls to the aforementioned APIs, and after 3 hours a reverse shell will be enabled. Follow the suggestions in the browser for commands to use to trigger anomalies.
 
 ![Screenshot](nodejs-traffic-generator.png)
+
+## App Configuration (Optional)
+### Environment Variables
+
+**`MIN_TIME`**: Optional. Set the minimum time before the reverse shell console is enabled (in seconds).

--- a/app/server.js
+++ b/app/server.js
@@ -26,7 +26,7 @@ const { Server } = require("socket.io");
 
 // Configurables
 var port = 8080
-var min_time_alive = 10800 // 3 hours
+var min_time_alive = process.env.MIN_TIME || 10800 // 3 hours
 var rse = false // reverse shell enabled
 
 // Initialize vars


### PR DESCRIPTION
Enable disabling (or adjusting) the countdown to rshell being active.

Supplied via environment var, `MIN_TIME`.  